### PR TITLE
Add who_can method

### DIFF
--- a/iamspy/cli.py
+++ b/iamspy/cli.py
@@ -69,7 +69,7 @@ def who_can(
     if Path(model).is_file():
         m.load_model(model)
 
-    print(m.who_can(action, resource, conditions, condition_file, strict_conditions))
+    print("\n".join(m.who_can(action, resource, conditions, condition_file, strict_conditions)))
 
 @app.callback()
 def main(verbose: int = typer.Option(0, "--verbose", "-v", count=True)):

--- a/iamspy/cli.py
+++ b/iamspy/cli.py
@@ -49,6 +49,27 @@ def can_i(
 
     print(m.can_i(source_arn, action, resource, conditions, condition_file, strict_conditions))
 
+@app.command()
+def who_can(
+    action: str = typer.Argument(...),
+    resource: str = typer.Argument(...),
+    conditions: List[str] = typer.Option([], "-c", help="List of conditions as key=value string pairs"),
+    condition_file: Optional[str] = typer.Option(
+        None, "-C", help="File of conditions to load following IAM condition syntax"
+    ),
+    strict_conditions: bool = typer.Option(
+        False, help="Whether to require conditions to be passed in for any IAM condition checks"
+    ),
+    model: str = typer.Option("model.smt2", "-f"),
+):
+    """
+    Pulls out applicable policies, runs who_can
+    """
+    m = Model()
+    if Path(model).is_file():
+        m.load_model(model)
+
+    print(m.who_can(action, resource, conditions, condition_file, strict_conditions))
 
 @app.callback()
 def main(verbose: int = typer.Option(0, "--verbose", "-v", count=True)):

--- a/iamspy/model.py
+++ b/iamspy/model.py
@@ -206,7 +206,9 @@ class Model:
                 s = z3.String('s')
                 m = solver.model()
                 source = m[s]
-                sources.append(source)
+                # breakpoint()
+
+                sources.append(str(source)[1:-1])
                 solver.add(s != source)
                 sat = solver.check() == z3.sat
             return sources

--- a/iamspy/model.py
+++ b/iamspy/model.py
@@ -184,7 +184,10 @@ class Model:
         conditions: List[str] = [],
         condition_file: Optional[str] = None,
         strict_conditions: bool = False,
-    ) -> bool:
+    ) -> list[str]:
+        """
+        Used by the CLI to provide the who-can call.
+        """
         with self as solver:
             logger.debug("Identifying model conditions")
             model_conditions = get_conditions(self.model_vars)
@@ -199,6 +202,7 @@ class Model:
                 strict_conditions=strict_conditions,
                 model_conditions=model_conditions,
             )
+
             solver.add(*query_conditions)
             sat = solver.check() == z3.sat
             sources = []
@@ -206,8 +210,6 @@ class Model:
                 s = z3.String('s')
                 m = solver.model()
                 source = m[s]
-                # breakpoint()
-
                 sources.append(str(source)[1:-1])
                 solver.add(s != source)
                 sat = solver.check() == z3.sat

--- a/iamspy/parse.py
+++ b/iamspy/parse.py
@@ -387,7 +387,7 @@ def generate_evaluation_logic_checks(model_vars, source: str, resource: str):
     else:
         identities = [x for x in model_vars if x.startswith('identity') and not x.endswith('_allow') and not x.endswith('_deny')]
         identities = [x for x in identities if len(x.split(':')) > 4 and (x.split(":")[5].startswith('user') or x.split(":")[5].startswith('role'))] 
-        identity_identifiers = [z3.And(z3.Bool(x), z3.Bool(f"{x}_deny"), s == x[9:], z3.String("s_account") == z3.StringVal(x.split(":")[4])) for x in identities]
+        identity_identifiers = [z3.And(z3.Bool(x), z3.Bool(f"{x}_deny"), s == x.lstrip("identity_"), z3.String("s_account") == z3.StringVal(x.split(":")[4])) for x in identities]
         identity_check = z3.Or(*identity_identifiers)
 
     constraints.append(z3.Bool("identity") == identity_check)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -105,7 +105,7 @@ import pytest
         ),
     ],
 )
-def test_all(files, inp, out):
+def test_can_i(files, inp, out):
     m = Model()
 
     base_path = pathlib.Path(__file__).parent / "files"
@@ -117,3 +117,101 @@ def test_all(files, inp, out):
         m.load_resource_policies(base_path / rp)
 
     assert m.can_i(*inp) == out
+
+@pytest.mark.parametrize(
+    "files,inp,out",
+    [
+        (
+            {"gaads": ["basic-allow.json"]},
+            (
+                "lambda:InvokeFunction",
+                "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
+            ),
+            set(['arn:aws:iam::123456789012:role/name','arn:aws:iam::123456789012:role/name_policy']),
+        ),
+        (
+              {"gaads": ["allow-testing-s3.json"], "resources": ["resource-s3-allow-testing.json"]},
+            (
+                
+                "s3:ListBucket",
+                "arn:aws:s3:::bucket",
+            ),
+            set(['arn:aws:iam::111111111111:role/testing', 'arn:aws:iam::111111111111:role/testing2_policy','arn:aws:iam::111111111111:role/testing2']),
+        ),
+        (
+         {"gaads": ["basic-allow.json"], "resources": ["cross-account-rp.json"]},
+            (
+                "lambda:InvokeFunction",
+                "arn:aws:lambda:eu-west-1:111111111111:function:helloworld",
+            ),
+            set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+        ),
+        (
+            {"gaads": ["allow-with-conditions.json"]},
+            (
+                "lambda:InvokeFunction",
+                "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
+            ),
+             set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+        ),
+        (
+            {"gaads": ["allow-with-conditions.json"]},
+            (
+                "lambda:InvokeFunction",
+                "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
+                [],
+                None,
+                True,
+            ),
+            set()
+        ),
+        (
+            {"gaads": ["allow-with-conditions.json"]},
+            (
+                "lambda:InvokeFunction",
+                "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
+                ["aws:referer=bobby.tables"],
+            ),
+            set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+        ),
+        (
+            {"gaads": ["allow-with-conditions.json"]},
+            (
+                "lambda:InvokeFunction",
+                "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
+                ["aws:referer=bobby.tables"],
+                None,
+                True,
+            ),
+            set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+        ),
+        (
+            {"gaads": ["allow-testing-s3.json"], "resources": ["resource-s3-allow-testing.json"]},
+            (
+                "s3:ListBucket",
+                "arn:aws:s3:::bucket",
+            ),
+            set(['arn:aws:iam::111111111111:role/testing','arn:aws:iam::111111111111:role/testing2', 'arn:aws:iam::111111111111:role/testing2_policy'])
+        ),
+        (
+            {"gaads": ["allow-testing-s3.json"], "resources": ["resource-s3-deny-testing2.json"]},
+            (
+                "s3:ListBucket",
+                "arn:aws:s3:::bucket",
+            ),
+            set([ 'arn:aws:iam::111111111111:role/testing2_policy'])
+        ),
+    ]
+)
+def test_who_can(files, inp, out):
+    m = Model()
+
+    base_path = pathlib.Path(__file__).parent / "files"
+
+    for gaad in files.get("gaads", []):
+        m.load_gaad(base_path / gaad)
+
+    for rp in files.get("resources", []):
+        m.load_resource_policies(base_path / rp)
+
+    assert set(m.who_can(*inp)) == out    


### PR DESCRIPTION
Adds a method to get all identities that can perform a particular action on a particular resource.
Tests need to be added and I'm still considering if we might want to exclude groups and policies from the identities. 