### PR TITLE
Avoid potential resource name collisions

### DIFF
--- a/iamspy/datatypes.py
+++ b/iamspy/datatypes.py
@@ -5,9 +5,8 @@ import string
 import z3
 from dateutil.parser import parse
 
-# A union set of all printable strings
-CHARSET = string.ascii_letters + string.digits + string.punctuation
-ANY = z3.Union(*[z3.Re(x) for x in CHARSET])
+# equivalient to chars in  string.ascii_letters + string.digits + string.punctuation
+ANY = z3.Range('!', '~')
 
 logger = logging.getLogger("iamspy.datatypes")
 

--- a/iamspy/parse.py
+++ b/iamspy/parse.py
@@ -383,8 +383,7 @@ def generate_evaluation_logic_checks(model_vars, source: str, resource: str):
         source_account = source.split(":")[4]
         constraints.append(z3.String("s_account") == z3.StringVal(source_account))
     else:
-        identities = [x for x in model_vars if x.startswith(
-            'identity') and not x.startswith('allow_') and not x.startswith('deny_')]
+        identities = [x for x in model_vars if x.startswith('identity')]
         identities = [x for x in identities if len(x.split(':')) > 4 and (
             x.split(":")[5].startswith('user') or x.split(":")[5].startswith('role'))]
         identity_identifiers = [z3.And(z3.Bool(x), z3.Bool(f"deny_{x}"), s == x.lstrip(

--- a/iamspy/parse.py
+++ b/iamspy/parse.py
@@ -21,9 +21,8 @@ from iamspy.conditions import condition_functions
 from iamspy.datatypes import parse_string
 from pydantic.json import pydantic_encoder
 
-# A union set of all printable strings
-CHARSET = string.ascii_letters + string.digits + string.punctuation
-ANY = z3.Union(*[z3.Re(x) for x in CHARSET])
+# equivalient to chars in  string.ascii_letters + string.digits + string.punctuation
+ANY = z3.Range('!', '~')
 logger = logging.getLogger("iamspy.parse")
 
 used_conditions = set()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -127,7 +127,7 @@ def test_can_i(files, inp, out):
                 "lambda:InvokeFunction",
                 "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
             ),
-            set(['arn:aws:iam::123456789012:role/name','arn:aws:iam::123456789012:role/name_policy']),
+            set(['arn:aws:iam::123456789012:role/name']),
         ),
         (
               {"gaads": ["allow-testing-s3.json"], "resources": ["resource-s3-allow-testing.json"]},
@@ -136,7 +136,7 @@ def test_can_i(files, inp, out):
                 "s3:ListBucket",
                 "arn:aws:s3:::bucket",
             ),
-            set(['arn:aws:iam::111111111111:role/testing', 'arn:aws:iam::111111111111:role/testing2_policy','arn:aws:iam::111111111111:role/testing2']),
+            set(['arn:aws:iam::111111111111:role/testing', 'arn:aws:iam::111111111111:role/testing2']),
         ),
         (
          {"gaads": ["basic-allow.json"], "resources": ["cross-account-rp.json"]},
@@ -144,7 +144,7 @@ def test_can_i(files, inp, out):
                 "lambda:InvokeFunction",
                 "arn:aws:lambda:eu-west-1:111111111111:function:helloworld",
             ),
-            set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+            set(['arn:aws:iam::123456789012:role/name'])
         ),
         (
             {"gaads": ["allow-with-conditions.json"]},
@@ -152,7 +152,7 @@ def test_can_i(files, inp, out):
                 "lambda:InvokeFunction",
                 "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
             ),
-             set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+             set(['arn:aws:iam::123456789012:role/name'])
         ),
         (
             {"gaads": ["allow-with-conditions.json"]},
@@ -172,7 +172,7 @@ def test_can_i(files, inp, out):
                 "arn:aws:lambda:eu-west-1:123456789012:function:helloworld",
                 ["aws:referer=bobby.tables"],
             ),
-            set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+            set(['arn:aws:iam::123456789012:role/name'])
         ),
         (
             {"gaads": ["allow-with-conditions.json"]},
@@ -183,7 +183,7 @@ def test_can_i(files, inp, out):
                 None,
                 True,
             ),
-            set(['arn:aws:iam::123456789012:role/name_policy', 'arn:aws:iam::123456789012:role/name'])
+            set(['arn:aws:iam::123456789012:role/name'])
         ),
         (
             {"gaads": ["allow-testing-s3.json"], "resources": ["resource-s3-allow-testing.json"]},
@@ -191,7 +191,7 @@ def test_can_i(files, inp, out):
                 "s3:ListBucket",
                 "arn:aws:s3:::bucket",
             ),
-            set(['arn:aws:iam::111111111111:role/testing','arn:aws:iam::111111111111:role/testing2', 'arn:aws:iam::111111111111:role/testing2_policy'])
+            set(['arn:aws:iam::111111111111:role/testing','arn:aws:iam::111111111111:role/testing2'])
         ),
         (
             {"gaads": ["allow-testing-s3.json"], "resources": ["resource-s3-deny-testing2.json"]},
@@ -199,7 +199,7 @@ def test_can_i(files, inp, out):
                 "s3:ListBucket",
                 "arn:aws:s3:::bucket",
             ),
-            set([ 'arn:aws:iam::111111111111:role/testing2_policy'])
+            set([])
         ),
     ]
 )


### PR DESCRIPTION
Also prepends 'policy' to policy identities to exclude from who can results. I'm not 100% sure this won't break anything but I suspect you will be able to tell me pretty quickly if it does. For what it's worth, I tested with our data set and the results were the same. 

I also changed the Union of printable characters to a range (the printable characters are all adjacent in the ascii table). This avoids the 'Re('a'), Re('b'), Re('c')' etc when viewing the model. Happy to change it back though if you feel the list comprehension is more pythonic (I didn't notice any difference in performance). 