### PR TITLE
Assume role bug: sts:AssumeRole is allowed without a permissions policy

### DIFF
--- a/tests/files/assume-role-just-trust.json
+++ b/tests/files/assume-role-just-trust.json
@@ -1,0 +1,80 @@
+{
+    "UserDetailList": [
+    ],
+    "GroupDetailList": [
+    ],
+    "RoleDetailList": [
+      {
+        "Path": "/",
+        "RoleName": "role-to-assume",
+        "RoleId": "AROAAAAAAAAAAAAAAAAAA",
+        "Arn": "arn:aws:iam::111111111111:role/role-to-assume",
+        "CreateDate": "2019-12-12 12:55:41+00:00",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "TrustRelationship",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::111111111111:role/role-assuming"
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "InstanceProfileList": [],
+        "RolePolicyList": [
+        ],
+        "AttachedManagedPolicies": [],
+        "Tags": [
+        ],
+        "RoleLastUsed": {}
+      },
+      {
+        "Path": "/",
+        "RoleName": "testing2",
+        "RoleId": "AROAAAAAAAAAAAAAAAAAB",
+        "Arn": "arn:aws:iam::111111111111:role/role-assuming",
+        "CreateDate": "2019-12-12 12:55:41+00:00",
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Sid": "TrustRelationship",
+              "Effect": "Allow",
+              "Principal": {
+                "AWS": "arn:aws:iam::111111111111:role/some-user"
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "InstanceProfileList": [],
+        "RolePolicyList": [
+          {
+            "PolicyName": "policy",
+            "PolicyDocument": {
+              "Version": "2012-10-17",
+              "Statement": [
+                {
+                  "Sid": "AllowS3",
+                  "Effect": "Allow",
+                  "Action": [
+                    "s3:*"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
+          }
+        ],
+        "AttachedManagedPolicies": [],
+        "Tags": [
+        ],
+        "RoleLastUsed": {}
+      }
+    ],
+    "Policies": [
+    ]
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -157,6 +157,15 @@ import pytest
             ),
             False,
         ),
+        (
+            {"gaads": ["assume-role-just-trust.json"]},
+            (
+                "arn:aws:iam::111111111111:role/role-assuming",
+                "sts:AssumeRole",
+                "arn:aws:iam::111111111111:role/role-to-assume",
+            ),
+            False,
+        ),
     ],
 )
 def test_can_i(files, inp, out):


### PR DESCRIPTION
This test case fails when it should succeed.

arn:aws:iam::111111111111:role/role-assuming has no identity permissions policy giving it sts:AssumeRole permission.
arn:aws:iam::111111111111:role/role-to-assume has a resource/trust policy allowing arn:aws:iam::111111111111:role/role-assuming to assume it

Both the identity and the resource policy need to allow the AssumeRole, however.