### PR TITLE
Handle * Principal value

### DIFF
--- a/iamspy/parse.py
+++ b/iamspy/parse.py
@@ -114,10 +114,14 @@ def _parse_statement(statement: Statements):
     if statement.Principal:
         # AWS Principals can not use wildcards
         # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
+        # except to specify All Principals
         # TODO: Makes these into an z3.Or
         if "AWS" in statement.Principal:
             items = []
             for principal in statement.Principal["AWS"]:
+                if principal == "*":
+                    items.append(True)
+                    continue
                 if re.match(r"[0-9]{12}", principal):
                     principal = f"arn:aws:iam::{principal}:root"
                 try:

--- a/tests/files/resource-s3-allow-all.json
+++ b/tests/files/resource-s3-allow-all.json
@@ -1,0 +1,18 @@
+[
+    {
+        "Resource": "arn:aws:s3:::bucket",
+        "Policy": {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Sid": "",
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": "*",
+                    "Resource": "*"
+                }
+            ]
+        },
+        "Account": "111111111111"
+    }
+]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -157,6 +157,15 @@ import pytest
             ),
             False,
         ),
+        (
+            {"gaads": ["allow-testing-s3.json"], "resources": ["resource-s3-allow-all.json"]},
+            (
+                "arn:aws:iam::111111111111:role/testing",
+                "s3:ListBucket",
+                "arn:aws:s3:::bucket",
+            ),
+            True,
+        ),
     ],
 )
 def test_can_i(files, inp, out):


### PR DESCRIPTION
It is possible for Principal to be * to refer to All Principals - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-anonymous

Without this, if an S3 bucket policy is Principal: * and Action: *, iamSpy always evaluates the resource check to false