### PR TITLE
fix(model): honour role trust policy as resource policy for sts:AssumeRole

### DIFF
--- a/iamspy/model.py
+++ b/iamspy/model.py
@@ -192,7 +192,15 @@ class Model:
             resource = list(additional_buckets) + resource
 
             for res in resource:
-                solver.add(*add_resource(self._model.resource_policies, res))
+                # A role's trust policy (AssumeRolePolicyDocument) is the
+                # resource policy for sts:AssumeRole, but it lives in the GAAD
+                # rather than in the explicitly loaded resource policies. If the
+                # resource is a role with no explicit resource policy, fall back
+                # to its trust policy so the assume can be evaluated.
+                if res not in self._model.resource_policies and (trust := self._get_role_trust_policy(res)):
+                    solver.add(*trust)
+                else:
+                    solver.add(*add_resource(self._model.resource_policies, res))
             logger.debug(f"Adding constraint resource is {resource}")
             solver.add(
                 z3.Or(
@@ -299,6 +307,32 @@ class Model:
 
         return org
 
+    def _get_role_trust_policy(self, resource: str):
+        """
+        Build the resource-policy constraints for an IAM role's trust policy
+        (AssumeRolePolicyDocument) from a loaded GAAD, or None if the resource
+        is not a role present in a GAAD.
+
+        A role's trust policy is the resource policy that governs
+        sts:AssumeRole, but it is stored in the GAAD rather than in the
+        explicitly loaded resource policies, so it is resolved here on demand.
+        """
+        try:
+            account_id = resource.split(":")[4]
+        except IndexError:
+            return None
+
+        gaad = self._model.gaads.get(account_id)
+        if not gaad:
+            return None
+
+        role = next((x for x in gaad.RoleDetailList if x.Arn == resource), None)
+        if not role:
+            return None
+
+        logger.debug(f"Using trust policy of {resource} as its resource policy")
+        return parse.parse_resource_policy(role.Arn, role.AssumeRolePolicyDocument)
+
     def get_correct_case_principal(self, principal: str) -> str:
         account_id = principal.split(":")[4]
         entity_type = principal.split(":")[5].split("/")[0]
@@ -317,7 +351,11 @@ class Model:
     def _check_viable_source_accounts(self, action: str, resource: str) -> Set[str]:
         all_source_accounts = list(self._model.gaads.keys())
         res_key = resource.split("/")[0] if resource.startswith("arn:aws:s3:::") and "/" in resource else resource
-        if res_key not in self._model.resource_policies:
+        # A role's trust policy acts as its resource policy (for sts:AssumeRole)
+        # even though it is not in resource_policies, so it can permit
+        # cross-account sources and must be evaluated per account below.
+        has_trust_policy = res_key not in self._model.resource_policies and self._get_role_trust_policy(res_key) is not None
+        if res_key not in self._model.resource_policies and not has_trust_policy:
             # No resource policy, assume same account only (unless it's an S3 bucket)
             if resource.startswith("arn:aws:s3:::"):
                 return set(all_source_accounts)

--- a/tests/files/assume-role-trust.json
+++ b/tests/files/assume-role-trust.json
@@ -1,0 +1,141 @@
+{
+  "UserDetailList": [],
+  "GroupDetailList": [],
+  "Policies": [],
+  "RoleDetailList": [
+    {
+      "Path": "/",
+      "RoleName": "Caller",
+      "RoleId": "AROACALLER",
+      "Arn": "arn:aws:iam::111111111111:role/Caller",
+      "CreateDate": "2024-01-01T00:00:00+00:00",
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      },
+      "InstanceProfileList": [],
+      "RolePolicyList": [
+        {
+          "PolicyName": "p",
+          "PolicyDocument": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "sts:AssumeRole",
+                "Resource": "*"
+              }
+            ]
+          }
+        }
+      ],
+      "AttachedManagedPolicies": [],
+      "Tags": [],
+      "RoleLastUsed": {}
+    },
+    {
+      "Path": "/",
+      "RoleName": "NoIdentityCaller",
+      "RoleId": "AROANOIDENTITY",
+      "Arn": "arn:aws:iam::111111111111:role/NoIdentityCaller",
+      "CreateDate": "2024-01-01T00:00:00+00:00",
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      },
+      "InstanceProfileList": [],
+      "RolePolicyList": [],
+      "AttachedManagedPolicies": [],
+      "Tags": [],
+      "RoleLastUsed": {}
+    },
+    {
+      "Path": "/",
+      "RoleName": "TrustingRole",
+      "RoleId": "AROATRUST",
+      "Arn": "arn:aws:iam::111111111111:role/TrustingRole",
+      "CreateDate": "2024-01-01T00:00:00+00:00",
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:role/Caller"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      },
+      "InstanceProfileList": [],
+      "RolePolicyList": [],
+      "AttachedManagedPolicies": [],
+      "Tags": [],
+      "RoleLastUsed": {}
+    },
+    {
+      "Path": "/",
+      "RoleName": "RootTrust",
+      "RoleId": "AROAROOT",
+      "Arn": "arn:aws:iam::111111111111:role/RootTrust",
+      "CreateDate": "2024-01-01T00:00:00+00:00",
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "AWS": "arn:aws:iam::111111111111:root"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      },
+      "InstanceProfileList": [],
+      "RolePolicyList": [],
+      "AttachedManagedPolicies": [],
+      "Tags": [],
+      "RoleLastUsed": {}
+    },
+    {
+      "Path": "/",
+      "RoleName": "NoTrust",
+      "RoleId": "AROANOTRUST",
+      "Arn": "arn:aws:iam::111111111111:role/NoTrust",
+      "CreateDate": "2024-01-01T00:00:00+00:00",
+      "AssumeRolePolicyDocument": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": {
+              "Service": "ec2.amazonaws.com"
+            },
+            "Action": "sts:AssumeRole"
+          }
+        ]
+      },
+      "InstanceProfileList": [],
+      "RolePolicyList": [],
+      "AttachedManagedPolicies": [],
+      "Tags": [],
+      "RoleLastUsed": {}
+    }
+  ]
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -220,6 +220,53 @@ import pytest
             ),
             True,
         ),
+        # sts:AssumeRole — target role's trust policy (AssumeRolePolicyDocument)
+        # must be honoured as the resource policy even though it is not loaded
+        # via load_resource_policies. Same-account assume is allowed iff the
+        # caller has identity permission AND the target trust allows the caller.
+        # Explicit-principal trust naming the caller role exactly.
+        (
+            {"gaads": ["assume-role-trust.json"]},
+            (
+                "arn:aws:iam::111111111111:role/Caller",
+                "sts:AssumeRole",
+                "arn:aws:iam::111111111111:role/TrustingRole",
+            ),
+            True,
+        ),
+        # Account-root (":root") trust delegates to identity policies in the
+        # account; the caller has sts:AssumeRole identity permission, so allowed.
+        (
+            {"gaads": ["assume-role-trust.json"]},
+            (
+                "arn:aws:iam::111111111111:role/Caller",
+                "sts:AssumeRole",
+                "arn:aws:iam::111111111111:role/RootTrust",
+            ),
+            True,
+        ),
+        # Target trust does not name the caller and is not a :root delegation,
+        # so the assume must be denied even though identity allows it.
+        (
+            {"gaads": ["assume-role-trust.json"]},
+            (
+                "arn:aws:iam::111111111111:role/Caller",
+                "sts:AssumeRole",
+                "arn:aws:iam::111111111111:role/NoTrust",
+            ),
+            False,
+        ),
+        # :root trust delegates to identity policies, so a caller WITHOUT the
+        # sts:AssumeRole identity permission is still denied.
+        (
+            {"gaads": ["assume-role-trust.json"]},
+            (
+                "arn:aws:iam::111111111111:role/NoIdentityCaller",
+                "sts:AssumeRole",
+                "arn:aws:iam::111111111111:role/RootTrust",
+            ),
+            False,
+        ),
     ],
 )
 def test_can_i(files, inp, out):
@@ -384,6 +431,16 @@ def test_can_i(files, inp, out):
                 "arn:aws:s3:::bucket/key",
             ),
             set(["arn:aws:iam::111111111111:user/userA", "arn:aws:iam::111111111111:user/userB"]),
+        ),
+        # who-can sts:AssumeRole resolves the target role's trust policy from the
+        # GAAD: only the caller with both identity permission and trust matches.
+        (
+            {"gaads": ["assume-role-trust.json"]},
+            (
+                "sts:AssumeRole",
+                "arn:aws:iam::111111111111:role/RootTrust",
+            ),
+            set(["arn:aws:iam::111111111111:role/Caller"]),
         ),
     ],
 )


### PR DESCRIPTION
## Summary

IAMSpy returns **denied** for `sts:AssumeRole` calls that AWS **allows**, for both same-account and cross-account assumes, whenever the target is an IAM role.

A role's trust policy (`AssumeRolePolicyDocument`) is the resource policy that governs `sts:AssumeRole`, but it lives in the GAAD rather than in the resource policies loaded via `load_resource_policies`. `generate_solver` only consulted `resource_policies`, so when a role was the **target** of an assume, `add_resource` found nothing and set `resource_<target> == False`. That makes `z3.Bool("resource")` unsatisfiable, and since the `sts:assumerole` rule requires `resource` to be true, every assume was denied.

This affected **both** an explicit `Principal:{AWS:".../Caller"}` trust and an account-root `Principal:{AWS:"...:root"}` trust — confirming the defect is in resource-side trust loading, not `:root` resolution.

## Root cause

`iamspy/model.py` — `generate_solver` resource loop only loaded explicitly-provided resource policies; a target role's trust doc was never loaded resource-side. A secondary instance in `_check_viable_source_accounts` pruned cross-account sources for trust-only roles, so `who_can` missed cross-account assumers.

## Fix

- Resolve a target role's trust policy from the loaded GAAD on demand when no explicit resource policy exists (new `_get_role_trust_policy` helper). Explicit resource policies still take precedence.
- Apply the same fallback in `_check_viable_source_accounts` so cross-account assumers are evaluated.

## Tests

First `sts:AssumeRole` integration tests in the suite:
- explicit-principal trust -> allowed
- `:root` delegation trust -> allowed
- non-matching trust -> denied
- `:root` trust but caller lacks `sts:AssumeRole` identity permission -> denied (delegation still requires identity)
- `who_can` resolves only the identity-permitted caller

All 46 tests pass.